### PR TITLE
🐛 Fix OffsetState constructor usage in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ var handler = new OffsetBased.Composite.PaginationHandlerBuilder<MyPage, int, My
         // Extract pagination state from the fetched page
         return new OffsetState<int>(
             pageContext.CurrentOffset,
-            pageContext.PageSize,
             pageContext.TotalItems);
     })
     .WithItemExtractor((MyPage pageContext, CancellationToken cancellationToken) =>


### PR DESCRIPTION
Corrected the OffsetState<int> constructor call in the offset-based pagination example by removing the incorrect pageSize parameter. The OffsetState constructor only takes currentOffset and totalItems parameters, not pageSize.

This ensures the README examples will actually compile when users copy them. ✨