### PR TITLE
Release 2.0.0

### DIFF
--- a/samples/EFCorePagination/Functions.cs
+++ b/samples/EFCorePagination/Functions.cs
@@ -1,3 +1,4 @@
+using EHonda.Pagination.CursorBased.Composite;
 using Microsoft.EntityFrameworkCore;
 
 namespace EFCorePagination;
@@ -34,7 +35,7 @@ public static class Functions
     {
         // TODO: Improve used types
         // TODO: Improve user experience
-        var handler = new CursorBased.Composite.PaginationHandlerBuilder<CursorBasedPaginationContext, int?, Movie>()
+        var handler = new PaginationHandlerBuilder<CursorBasedPaginationContext, int?, Movie>()
             .WithPageRetriever(async (paginationContext, cancellationToken) =>
             {
                 await using var dbContext = new MoviesDbContext();
@@ -59,7 +60,7 @@ public static class Functions
 
     public static IAsyncEnumerable<Movie> GetMoviesPaginatedOffsetBased()
     {
-        var handler = new OffsetBased.Composite.PaginationHandlerBuilder<OffsetBasedPaginationContext, Movie>()
+        var handler = new EHonda.Pagination.OffsetBased.Composite.PaginationHandlerBuilder<OffsetBasedPaginationContext, Movie>()
             .WithPageRetriever(async (paginationContext, cancellationToken) =>
             {
                 await using var dbContext = new MoviesDbContext();

--- a/samples/SpotifyPagination/Artists/ArtistsClient.cs
+++ b/samples/SpotifyPagination/Artists/ArtistsClient.cs
@@ -1,6 +1,7 @@
 using System.Net.Http.Json;
 using System.Text.Json;
 using Ardalis.GuardClauses;
+using EHonda.Pagination.CursorBased.Composite;
 
 namespace SpotifyPagination.Artists;
 
@@ -58,7 +59,7 @@ public class ArtistsClient
     // We can also do cursor based thanks to the `Next` property in the responses
     public IAsyncEnumerable<Album> GetAlbumsCursorBased(string artistId)
     {
-        var handler = new CursorBased.Composite.PaginationHandlerBuilder<GetAlbumsResponse, Album>()
+        var handler = new PaginationHandlerBuilder<GetAlbumsResponse, Album>()
             .WithPageRetriever(async (context, cancellationToken) =>
             {
                 const int limit = 10;

--- a/samples/SpotifyPagination/Artists/OffsetBasedPagination/AlbumsPaginationHandler.cs
+++ b/samples/SpotifyPagination/Artists/OffsetBasedPagination/AlbumsPaginationHandler.cs
@@ -1,4 +1,4 @@
-using OffsetBased;
+using EHonda.Pagination.OffsetBased;
 
 namespace SpotifyPagination.Artists.OffsetBasedPagination;
 

--- a/samples/SpotifyPagination/Artists/OffsetBasedPagination/Composite/AlbumsPaginationHandler.cs
+++ b/samples/SpotifyPagination/Artists/OffsetBasedPagination/Composite/AlbumsPaginationHandler.cs
@@ -1,4 +1,4 @@
-using OffsetBased.Composite;
+using EHonda.Pagination.OffsetBased.Composite;
 
 namespace SpotifyPagination.Artists.OffsetBasedPagination.Composite;
 

--- a/samples/SpotifyPagination/Artists/OffsetBasedPagination/Composite/ItemExtractor.cs
+++ b/samples/SpotifyPagination/Artists/OffsetBasedPagination/Composite/ItemExtractor.cs
@@ -1,4 +1,4 @@
-using Sequential.Composite.ItemExtractors;
+using EHonda.Pagination.Sequential.Composite.ItemExtractors;
 
 namespace SpotifyPagination.Artists.OffsetBasedPagination.Composite;
 

--- a/samples/SpotifyPagination/Artists/OffsetBasedPagination/Composite/OffsetStateExtractor.cs
+++ b/samples/SpotifyPagination/Artists/OffsetBasedPagination/Composite/OffsetStateExtractor.cs
@@ -1,5 +1,5 @@
-using OffsetBased;
-using OffsetBased.Composite.OffsetStateExtractors;
+using EHonda.Pagination.OffsetBased;
+using EHonda.Pagination.OffsetBased.Composite.OffsetStateExtractors;
 
 namespace SpotifyPagination.Artists.OffsetBasedPagination.Composite;
 

--- a/samples/SpotifyPagination/Artists/OffsetBasedPagination/Composite/PageRetriever.cs
+++ b/samples/SpotifyPagination/Artists/OffsetBasedPagination/Composite/PageRetriever.cs
@@ -1,4 +1,4 @@
-using Sequential.Composite.PageRetrievers;
+using EHonda.Pagination.Sequential.Composite.PageRetrievers;
 
 namespace SpotifyPagination.Artists.OffsetBasedPagination.Composite;
 

--- a/samples/SpotifyPagination/Program.cs
+++ b/samples/SpotifyPagination/Program.cs
@@ -1,6 +1,4 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
-using OffsetBased;
-using OffsetBased.Composite;
 using SpotifyPagination;
 using SpotifyPagination.Artists;
 using SpotifyPagination.Artists.OffsetBasedPagination.Composite;

--- a/samples/TwitchPagination/Games/Composite/CursorExtractor.cs
+++ b/samples/TwitchPagination/Games/Composite/CursorExtractor.cs
@@ -1,4 +1,4 @@
-using CursorBased.Composite.CursorExtractors;
+using EHonda.Pagination.CursorBased.Composite.CursorExtractors;
 
 namespace TwitchPagination.Games.Composite;
 

--- a/samples/TwitchPagination/Games/Composite/ItemExtractor.cs
+++ b/samples/TwitchPagination/Games/Composite/ItemExtractor.cs
@@ -1,4 +1,4 @@
-using Sequential.Composite.ItemExtractors;
+using EHonda.Pagination.Sequential.Composite.ItemExtractors;
 
 namespace TwitchPagination.Games.Composite;
 

--- a/samples/TwitchPagination/Games/Composite/PageRetriever.cs
+++ b/samples/TwitchPagination/Games/Composite/PageRetriever.cs
@@ -1,5 +1,5 @@
+using EHonda.Pagination.Sequential.Composite.PageRetrievers;
 using JetBrains.Annotations;
-using Sequential.Composite.PageRetrievers;
 
 namespace TwitchPagination.Games.Composite;
 

--- a/samples/TwitchPagination/Games/Composite/TopGamesPaginationHandler.cs
+++ b/samples/TwitchPagination/Games/Composite/TopGamesPaginationHandler.cs
@@ -1,4 +1,4 @@
-using CursorBased.Composite;
+using EHonda.Pagination.CursorBased.Composite;
 using JetBrains.Annotations;
 
 namespace TwitchPagination.Games.Composite;

--- a/samples/TwitchPagination/Games/GamesClient.cs
+++ b/samples/TwitchPagination/Games/GamesClient.cs
@@ -1,7 +1,7 @@
 using System.Net.Http.Json;
 using System.Text.Json;
 using Ardalis.GuardClauses;
-using CursorBased.Composite;
+using EHonda.Pagination.CursorBased.Composite;
 using TwitchPagination.Games.Composite;
 
 namespace TwitchPagination.Games;

--- a/samples/TwitchPagination/Games/TopGamesPaginationHandler.cs
+++ b/samples/TwitchPagination/Games/TopGamesPaginationHandler.cs
@@ -1,4 +1,4 @@
-using CursorBased;
+using EHonda.Pagination.CursorBased;
 using JetBrains.Annotations;
 
 namespace TwitchPagination.Games;

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -2,16 +2,9 @@
 
   <PropertyGroup>
     <!-- Specific to this project -->
-    <PackageId>EHonda.Pagination.Core</PackageId>
     <Description>Core interfaces and building blocks for pagination.</Description>
-    <PackageTags>pagination paging</PackageTags>
-    <DefineConstants>JETBRAINS_ANNOTATIONS</DefineConstants>
   </PropertyGroup>
 
   <!-- Common properties are imported from Directory.Build.props -->
-
-  <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" />
-  </ItemGroup>
 
 </Project>

--- a/src/Core/IPaginationHandler.cs
+++ b/src/Core/IPaginationHandler.cs
@@ -1,6 +1,6 @@
 using JetBrains.Annotations;
 
-namespace Core;
+namespace EHonda.Pagination.Core;
 
 /// <summary>
 /// A pagination handler is responsible for retrieving all items from a paginated resource.

--- a/src/CursorBased/Composite/CursorExtractors/ByAsyncFunction.cs
+++ b/src/CursorBased/Composite/CursorExtractors/ByAsyncFunction.cs
@@ -1,4 +1,4 @@
-namespace CursorBased.Composite.CursorExtractors;
+namespace EHonda.Pagination.CursorBased.Composite.CursorExtractors;
 
 /// <summary>
 /// Extracts a cursor from a pagination context using an asynchronous function.

--- a/src/CursorBased/Composite/CursorExtractors/ByFunction.cs
+++ b/src/CursorBased/Composite/CursorExtractors/ByFunction.cs
@@ -1,4 +1,4 @@
-namespace CursorBased.Composite.CursorExtractors;
+namespace EHonda.Pagination.CursorBased.Composite.CursorExtractors;
 
 /// <summary>
 /// Extracts a cursor from a pagination context using a synchronous function.

--- a/src/CursorBased/Composite/CursorExtractors/ICursorExtractor.cs
+++ b/src/CursorBased/Composite/CursorExtractors/ICursorExtractor.cs
@@ -1,4 +1,4 @@
-namespace CursorBased.Composite.CursorExtractors;
+namespace EHonda.Pagination.CursorBased.Composite.CursorExtractors;
 
 /// <summary>
 /// Defines a contract for extracting a cursor from a pagination context, defaulting to a string cursor type.

--- a/src/CursorBased/Composite/NextPageChecker.cs
+++ b/src/CursorBased/Composite/NextPageChecker.cs
@@ -1,7 +1,7 @@
-using CursorBased.Composite.CursorExtractors;
-using Sequential.Composite.NextPageCheckers;
+using EHonda.Pagination.CursorBased.Composite.CursorExtractors;
+using EHonda.Pagination.Sequential.Composite.NextPageCheckers;
 
-namespace CursorBased.Composite;
+namespace EHonda.Pagination.CursorBased.Composite;
 
 /// <summary>
 /// Checks for the existence of a next page in a cursor-based pagination context, using a string cursor.

--- a/src/CursorBased/Composite/PaginationHandler.cs
+++ b/src/CursorBased/Composite/PaginationHandler.cs
@@ -1,9 +1,9 @@
-using CursorBased.Composite.CursorExtractors;
+using EHonda.Pagination.CursorBased.Composite.CursorExtractors;
+using EHonda.Pagination.Sequential.Composite.ItemExtractors;
+using EHonda.Pagination.Sequential.Composite.PageRetrievers;
 using JetBrains.Annotations;
-using Sequential.Composite.ItemExtractors;
-using Sequential.Composite.PageRetrievers;
 
-namespace CursorBased.Composite;
+namespace EHonda.Pagination.CursorBased.Composite;
 
 /// <summary>
 /// Handles cursor-based pagination by composing page retrieval, cursor extraction, and item extraction logic.

--- a/src/CursorBased/Composite/PaginationHandlerBuilder.cs
+++ b/src/CursorBased/Composite/PaginationHandlerBuilder.cs
@@ -1,9 +1,9 @@
 using Ardalis.GuardClauses;
-using CursorBased.Composite.CursorExtractors;
-using Sequential.Composite.ItemExtractors;
-using Sequential.Composite.PageRetrievers;
+using EHonda.Pagination.CursorBased.Composite.CursorExtractors;
+using EHonda.Pagination.Sequential.Composite.ItemExtractors;
+using EHonda.Pagination.Sequential.Composite.PageRetrievers;
 
-namespace CursorBased.Composite;
+namespace EHonda.Pagination.CursorBased.Composite;
 
 /// <summary>
 /// A builder for creating instances of <see cref="PaginationHandler{TPaginationContext, TItem}"/>, 

--- a/src/CursorBased/CursorBased.csproj
+++ b/src/CursorBased/CursorBased.csproj
@@ -2,9 +2,8 @@
 
     <PropertyGroup>
         <!-- Specific to this project -->
-        <PackageId>EHonda.Pagination.CursorBased</PackageId>
         <Description>Cursor-based pagination implementation.</Description>
-        <PackageTags>pagination cursor-based paging</PackageTags>
+        <PackageTags>$(PackageTags) cursor-based</PackageTags>
     </PropertyGroup>
 
     <!-- Common properties are imported from Directory.Build.props -->

--- a/src/CursorBased/PaginationHandler.cs
+++ b/src/CursorBased/PaginationHandler.cs
@@ -1,4 +1,4 @@
-namespace CursorBased;
+namespace EHonda.Pagination.CursorBased;
 
 public abstract class PaginationHandler<TPaginationContext, TItem>
     : PaginationHandler<TPaginationContext, string, TItem>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,12 +3,13 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <RootNamespace>EHonda.Pagination.$(MSBuildProjectName)</RootNamespace>
     <Authors>Dennis Renz</Authors>
     <Copyright>Copyright (c) Dennis Renz 2025</Copyright>
     <PackageProjectUrl>https://github.com/ehonda/Pagination</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.0.0</Version> <!-- Common version for all packages in src -->
+    <Version>2.0.0</Version> <!-- Common version for all packages in src -->
     <PackageReleaseNotes>See package release notes on GitHub: https://github.com/ehonda/Pagination/releases/tag/v$(Version)</PackageReleaseNotes>
 
     <!-- Symbol Packaging -->

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,13 +4,16 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>EHonda.Pagination.$(MSBuildProjectName)</RootNamespace>
+    <PackageId>$(RootNamespace)</PackageId>
     <Authors>Dennis Renz</Authors>
     <Copyright>Copyright (c) Dennis Renz 2025</Copyright>
     <PackageProjectUrl>https://github.com/ehonda/Pagination</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageTags>pagination paging</PackageTags>
     <Version>2.0.0</Version> <!-- Common version for all packages in src -->
     <PackageReleaseNotes>See package release notes on GitHub: https://github.com/ehonda/Pagination/releases/tag/v$(Version)</PackageReleaseNotes>
+    <DefineConstants>JETBRAINS_ANNOTATIONS</DefineConstants>
 
     <!-- Symbol Packaging -->
     <IncludeSymbols>true</IncludeSymbols>
@@ -26,5 +29,9 @@
          PackagePath="" ensures it's at the root of the NuGet package.
          $(MSBuildThisFileDirectory) refers to the 'src' directory where this Directory.Build.props file is located. -->
     <None Include="$(MSBuildThisFileDirectory)../README.md" Pack="true" PackagePath="" Link="README.md" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/OffsetBased/Composite/NextPageChecker.cs
+++ b/src/OffsetBased/Composite/NextPageChecker.cs
@@ -1,8 +1,8 @@
 using System.Numerics;
-using OffsetBased.Composite.OffsetStateExtractors;
-using Sequential.Composite.NextPageCheckers;
+using EHonda.Pagination.OffsetBased.Composite.OffsetStateExtractors;
+using EHonda.Pagination.Sequential.Composite.NextPageCheckers;
 
-namespace OffsetBased.Composite;
+namespace EHonda.Pagination.OffsetBased.Composite;
 
 /// <summary>
 /// Checks if a next page exists for offset-based pagination using an <see cref="IOffsetStateExtractor{TPaginationContext, TIndex}"/>.

--- a/src/OffsetBased/Composite/OffsetStateExtractors/ByAsyncFunction.cs
+++ b/src/OffsetBased/Composite/OffsetStateExtractors/ByAsyncFunction.cs
@@ -1,6 +1,6 @@
 using System.Numerics;
 
-namespace OffsetBased.Composite.OffsetStateExtractors;
+namespace EHonda.Pagination.OffsetBased.Composite.OffsetStateExtractors;
 
 /// <summary>
 /// Extracts offset-based pagination state using an asynchronous function.

--- a/src/OffsetBased/Composite/OffsetStateExtractors/ByFunction.cs
+++ b/src/OffsetBased/Composite/OffsetStateExtractors/ByFunction.cs
@@ -1,6 +1,6 @@
 using System.Numerics;
 
-namespace OffsetBased.Composite.OffsetStateExtractors;
+namespace EHonda.Pagination.OffsetBased.Composite.OffsetStateExtractors;
 
 /// <summary>
 /// Extracts offset-based pagination state using a synchronous function.

--- a/src/OffsetBased/Composite/OffsetStateExtractors/IOffsetStateExtractor.cs
+++ b/src/OffsetBased/Composite/OffsetStateExtractors/IOffsetStateExtractor.cs
@@ -1,6 +1,6 @@
 using System.Numerics;
 
-namespace OffsetBased.Composite.OffsetStateExtractors;
+namespace EHonda.Pagination.OffsetBased.Composite.OffsetStateExtractors;
 
 /// <summary>
 /// Defines a contract for extracting offset-based pagination state.

--- a/src/OffsetBased/Composite/PaginationHandler.cs
+++ b/src/OffsetBased/Composite/PaginationHandler.cs
@@ -1,9 +1,9 @@
 using System.Numerics;
-using OffsetBased.Composite.OffsetStateExtractors;
-using Sequential.Composite.ItemExtractors;
-using Sequential.Composite.PageRetrievers;
+using EHonda.Pagination.OffsetBased.Composite.OffsetStateExtractors;
+using EHonda.Pagination.Sequential.Composite.ItemExtractors;
+using EHonda.Pagination.Sequential.Composite.PageRetrievers;
 
-namespace OffsetBased.Composite;
+namespace EHonda.Pagination.OffsetBased.Composite;
 
 /// <summary>
 /// A composite pagination handler for offset-based pagination.

--- a/src/OffsetBased/Composite/PaginationHandlerBuilder.cs
+++ b/src/OffsetBased/Composite/PaginationHandlerBuilder.cs
@@ -1,10 +1,10 @@
 using System.Numerics;
 using Ardalis.GuardClauses;
-using OffsetBased.Composite.OffsetStateExtractors;
-using Sequential.Composite.ItemExtractors;
-using Sequential.Composite.PageRetrievers;
+using EHonda.Pagination.OffsetBased.Composite.OffsetStateExtractors;
+using EHonda.Pagination.Sequential.Composite.ItemExtractors;
+using EHonda.Pagination.Sequential.Composite.PageRetrievers;
 
-namespace OffsetBased.Composite;
+namespace EHonda.Pagination.OffsetBased.Composite;
 
 /// <summary>
 /// A builder for creating instances of <see cref="PaginationHandler{TPaginationContext, TItem}"/>.

--- a/src/OffsetBased/OffsetBased.csproj
+++ b/src/OffsetBased/OffsetBased.csproj
@@ -2,9 +2,8 @@
 
     <PropertyGroup>
         <!-- Specific to this project -->
-        <PackageId>EHonda.Pagination.OffsetBased</PackageId>
         <Description>Provides offset-based pagination functionality.</Description>
-        <PackageTags>pagination offset-based offset paging</PackageTags>
+        <PackageTags>$(PackageTags) offset-based offset</PackageTags>
     </PropertyGroup>
 
     <!-- Common properties are imported from Directory.Build.props -->

--- a/src/OffsetBased/OffsetState.cs
+++ b/src/OffsetBased/OffsetState.cs
@@ -1,4 +1,4 @@
-namespace OffsetBased;
+namespace EHonda.Pagination.OffsetBased;
 
 /// <summary>
 /// Represents the state used for offset-based pagination, including the current offset and the total number of items.

--- a/src/OffsetBased/PaginationHandler.cs
+++ b/src/OffsetBased/PaginationHandler.cs
@@ -1,6 +1,6 @@
 using System.Numerics;
 
-namespace OffsetBased;
+namespace EHonda.Pagination.OffsetBased;
 
 /// <summary>
 /// Extends the sequential pagination handler to support offset-based pagination.

--- a/src/Sequential/Composite/ItemExtractors/ByAsyncFunction.cs
+++ b/src/Sequential/Composite/ItemExtractors/ByAsyncFunction.cs
@@ -1,4 +1,4 @@
-namespace Sequential.Composite.ItemExtractors;
+namespace EHonda.Pagination.Sequential.Composite.ItemExtractors;
 
 /// <summary>
 /// Extracts items from a pagination context using an asynchronous function.

--- a/src/Sequential/Composite/ItemExtractors/ByFunction.cs
+++ b/src/Sequential/Composite/ItemExtractors/ByFunction.cs
@@ -1,4 +1,4 @@
-namespace Sequential.Composite.ItemExtractors;
+namespace EHonda.Pagination.Sequential.Composite.ItemExtractors;
 
 /// <summary>
 /// Extracts items from a pagination context using a synchronous function.

--- a/src/Sequential/Composite/ItemExtractors/IItemExtractor.cs
+++ b/src/Sequential/Composite/ItemExtractors/IItemExtractor.cs
@@ -1,6 +1,6 @@
 using JetBrains.Annotations;
 
-namespace Sequential.Composite.ItemExtractors;
+namespace EHonda.Pagination.Sequential.Composite.ItemExtractors;
 
 /// <summary>
 /// Defines a contract for extracting items from a pagination context.

--- a/src/Sequential/Composite/NextPageCheckers/ByAsyncFunction.cs
+++ b/src/Sequential/Composite/NextPageCheckers/ByAsyncFunction.cs
@@ -1,4 +1,4 @@
-namespace Sequential.Composite.NextPageCheckers;
+namespace EHonda.Pagination.Sequential.Composite.NextPageCheckers;
 
 /// <summary>
 /// Checks for the existence of a next page using an asynchronous function.

--- a/src/Sequential/Composite/NextPageCheckers/ByFunction.cs
+++ b/src/Sequential/Composite/NextPageCheckers/ByFunction.cs
@@ -1,4 +1,4 @@
-namespace Sequential.Composite.NextPageCheckers;
+namespace EHonda.Pagination.Sequential.Composite.NextPageCheckers;
 
 /// <summary>
 /// Checks for the existence of a next page using a synchronous function.

--- a/src/Sequential/Composite/NextPageCheckers/INextPageChecker.cs
+++ b/src/Sequential/Composite/NextPageCheckers/INextPageChecker.cs
@@ -1,6 +1,6 @@
 using JetBrains.Annotations;
 
-namespace Sequential.Composite.NextPageCheckers;
+namespace EHonda.Pagination.Sequential.Composite.NextPageCheckers;
 
 /// <summary>
 /// Defines a contract for checking if a next page exists in a pagination context.

--- a/src/Sequential/Composite/PageRetrievers/ByAsyncFunction.cs
+++ b/src/Sequential/Composite/PageRetrievers/ByAsyncFunction.cs
@@ -1,4 +1,4 @@
-namespace Sequential.Composite.PageRetrievers;
+namespace EHonda.Pagination.Sequential.Composite.PageRetrievers;
 
 /// <summary>
 /// Retrieves a page of data using an asynchronous function.

--- a/src/Sequential/Composite/PageRetrievers/ByFunction.cs
+++ b/src/Sequential/Composite/PageRetrievers/ByFunction.cs
@@ -1,4 +1,4 @@
-namespace Sequential.Composite.PageRetrievers;
+namespace EHonda.Pagination.Sequential.Composite.PageRetrievers;
 
 // TODO: Is there any benefit in implementing this via the async variant? Are there any downsides? Maybe benchmark the
 //       difference

--- a/src/Sequential/Composite/PageRetrievers/IPageRetriever.cs
+++ b/src/Sequential/Composite/PageRetrievers/IPageRetriever.cs
@@ -1,6 +1,6 @@
 ﻿using JetBrains.Annotations;
 
-namespace Sequential.Composite.PageRetrievers;
+namespace EHonda.Pagination.Sequential.Composite.PageRetrievers;
 
 /// <summary>
 /// Defines a contract for retrieving a page of data in a pagination context.

--- a/src/Sequential/Composite/PaginationHandler.cs
+++ b/src/Sequential/Composite/PaginationHandler.cs
@@ -1,7 +1,7 @@
+using EHonda.Pagination.Sequential.Composite.PageRetrievers;
 using JetBrains.Annotations;
-using Sequential.Composite.PageRetrievers;
 
-namespace Sequential.Composite;
+namespace EHonda.Pagination.Sequential.Composite;
 
 /// <summary>
 /// Handles sequential pagination by composing page retrieval, next page checking, and item extraction logic.

--- a/src/Sequential/Composite/PaginationHandlerBuilder.cs
+++ b/src/Sequential/Composite/PaginationHandlerBuilder.cs
@@ -1,10 +1,10 @@
 using Ardalis.GuardClauses;
+using EHonda.Pagination.Sequential.Composite.ItemExtractors;
+using EHonda.Pagination.Sequential.Composite.NextPageCheckers;
+using EHonda.Pagination.Sequential.Composite.PageRetrievers;
 using JetBrains.Annotations;
-using Sequential.Composite.ItemExtractors;
-using Sequential.Composite.NextPageCheckers;
-using Sequential.Composite.PageRetrievers;
 
-namespace Sequential.Composite;
+namespace EHonda.Pagination.Sequential.Composite;
 
 /// <summary>
 /// A builder for creating instances of <see cref="PaginationHandler{TPaginationContext, TItem}"/>.

--- a/src/Sequential/PaginationHandler.cs
+++ b/src/Sequential/PaginationHandler.cs
@@ -1,8 +1,8 @@
 using System.Runtime.CompilerServices;
-using Core;
+using EHonda.Pagination.Core;
 using JetBrains.Annotations;
 
-namespace Sequential;
+namespace EHonda.Pagination.Sequential;
 
 /// <summary>
 /// Handles paginated resources by sequentially fetching pages. It uses a context object (<typeparamref name="TPaginationContext"/>)

--- a/src/Sequential/Sequential.csproj
+++ b/src/Sequential/Sequential.csproj
@@ -2,9 +2,8 @@
 
     <PropertyGroup>
         <!-- Specific to this project -->
-        <PackageId>EHonda.Pagination.Sequential</PackageId>
         <Description>Provides sequential pagination functionality.</Description>
-        <PackageTags>pagination sequential paging</PackageTags>
+        <PackageTags>$(PackageTags) sequential</PackageTags>
     </PropertyGroup>
 
     <!-- Common properties are imported from Directory.Build.props -->

--- a/tests/CursorBased.TUnit.Tests/PaginationHandlerTests.cs
+++ b/tests/CursorBased.TUnit.Tests/PaginationHandlerTests.cs
@@ -1,5 +1,5 @@
-using Core;
-using CursorBased.Composite;
+using EHonda.Pagination.Core;
+using EHonda.Pagination.CursorBased.Composite;
 
 namespace CursorBased.TUnit.Tests;
 

--- a/tests/OffsetBased.TUnit.Tests/PaginationHandlerTests.cs
+++ b/tests/OffsetBased.TUnit.Tests/PaginationHandlerTests.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
-using Core;
-using OffsetBased.Composite;
+using EHonda.Pagination.Core;
+using EHonda.Pagination.OffsetBased;
+using EHonda.Pagination.OffsetBased.Composite;
 
 namespace OffsetBased.TUnit.Tests;
 

--- a/tests/Sequential.TUnit.Tests/PaginationHandlerTests.cs
+++ b/tests/Sequential.TUnit.Tests/PaginationHandlerTests.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
-using Core;
+using EHonda.Pagination.Core;
+using EHonda.Pagination.Sequential;
 
 namespace Sequential.TUnit.Tests;
 


### PR DESCRIPTION
This pull request refactors namespaces across multiple files to align them with the `EHonda.Pagination` structure, ensuring consistency and clarity in the codebase. Additionally, it removes unused project-specific metadata from the `Core.csproj` file.

### Namespace Refactoring:

* Updated namespaces in `samples/EFCorePagination/Functions.cs` and `samples/SpotifyPagination/Artists/ArtistsClient.cs` to use `EHonda.Pagination.CursorBased.Composite` and `EHonda.Pagination.OffsetBased.Composite` respectively. [[1]](diffhunk://#diff-0288caf8433659d31e2022293c975e8c1bf29443e3b7674d648c2df76db123e3R1) [[2]](diffhunk://#diff-8b6fbe34aede46a522e7950428ded7ac0753e371ea7854799245e69fb5673e7dR4) [[3]](diffhunk://#diff-0288caf8433659d31e2022293c975e8c1bf29443e3b7674d648c2df76db123e3L62-R63)
* Changed namespaces in `samples/TwitchPagination/Games` files to use `EHonda.Pagination.CursorBased.Composite` and `EHonda.Pagination.Sequential.Composite.ItemExtractors`. [[1]](diffhunk://#diff-a0d74c65ebaa7ef751c6d2bec7e58bcb9fee7d82888a261ee6e49fa76cc475fdL1-R1) [[2]](diffhunk://#diff-8c8bfd82d19b15aa2a1fe06c7f70d05e0225cc200e78ba1f2ca9bf68ad48a2aaL1-R1) [[3]](diffhunk://#diff-121fd9603b265a55bef10800a778e31b4805dbbe1d9cd332d6e6adeb2ad23f14R1-L2) [[4]](diffhunk://#diff-10d06a5b1621d8994fe5da0767b28c3e0a03941c81d48e53c66b54b8b517f23dL1-R1) [[5]](diffhunk://#diff-8ba9d40c602e644184ef64206b1061a7faa1562cc5f3c7379b22d4b44bf2d728L1-R1) [[6]](diffhunk://#diff-557db021ebaa1ca5bd5a665e5add86e7a28e8875c7df1857fb359884d100ecb8L4-R4)

### Project Metadata Cleanup:

* Removed unused constants and package references from `src/Core/Core.csproj`. This includes `PackageTags`, `DefineConstants`, and the `JetBrains.Annotations` package.

### Core Namespace Update:

* Refactored `src/Core/IPaginationHandler.cs` to use the `EHonda.Pagination.Core` namespace instead of `Core`.

### Cursor-Based Pagination Updates:

* Updated namespaces in cursor-based pagination files, such as `ByFunction.cs`, `ByAsyncFunction.cs`, and `ICursorExtractor.cs`, to use `EHonda.Pagination.CursorBased.Composite.CursorExtractors`. [[1]](diffhunk://#diff-ad7992e80b035c8bf9841fd60d1f698da6e25fecf4528b8febe8e1541ac72b06L1-R1) [[2]](diffhunk://#diff-298cbbba840819810c1b90dc7577effb0c9b87e2e66802a773a6e780671a24d2L1-R1) [[3]](diffhunk://#diff-8151da1c0e4cb72373e1fbd39b329b20843fb12f16f49bae6935ec0cc32103b6L1-R1)
* Refactored `NextPageChecker.cs` to use `EHonda.Pagination.CursorBased.Composite.CursorExtractors` and `EHonda.Pagination.Sequential.Composite.NextPageCheckers`.