### PR TITLE
feat(release): Correct package release notes URL

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -11,7 +11,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageTags>pagination paging</PackageTags>
-    <Version>2.0.0</Version> <!-- Common version for all packages in src -->
+    <Version>2.0.1</Version> <!-- Common version for all packages in src -->
     <PackageReleaseNotes>See package release notes on GitHub: https://github.com/ehonda/Pagination/releases/tag/$(PackageId)-v$(Version)</PackageReleaseNotes>
     <DefineConstants>JETBRAINS_ANNOTATIONS</DefineConstants>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -12,7 +12,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageTags>pagination paging</PackageTags>
     <Version>2.0.0</Version> <!-- Common version for all packages in src -->
-    <PackageReleaseNotes>See package release notes on GitHub: https://github.com/ehonda/Pagination/releases/tag/v$(Version)</PackageReleaseNotes>
+    <PackageReleaseNotes>See package release notes on GitHub: https://github.com/ehonda/Pagination/releases/tag/$(PackageId)-v$(Version)</PackageReleaseNotes>
     <DefineConstants>JETBRAINS_ANNOTATIONS</DefineConstants>
 
     <!-- Symbol Packaging -->


### PR DESCRIPTION
This pull request includes a version update and a minor adjustment to the release notes URL format in the `src/Directory.Build.props` file.

* Updated the package version from `2.0.0` to `2.0.1`.
* Modified the `PackageReleaseNotes` property to include `PackageId` in the release notes URL format for better specificity.The package release notes URL was incorrect, leading to a 404 page. This was because the URL was missing the package ID